### PR TITLE
Fix: Force pencil icon to fill 256x256 area

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 <p align="center">
-  <a href="https://github.com/erkinalp/EditTogether"><img src="public/icons/LogoEditTogether256px.png" alt="Logo"></img></a>
+  <a href="https://github.com/erkinalp/EditTogether"><img src="public/icons/pencil.svg" alt="Logo"></img></a>
 
   <br/>
-  <sub>Logo by <a href="https://github.com/munadikieh">@munadikieh</a></sub>
 </p>
 
 <h1 align="center">EditTogether</h1>
@@ -66,6 +65,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md)
 The awesome [Invidious API](https://docs.invidious.io/) was previously used, and the server is now using [NewLeaf](https://git.sr.ht/~cadence/NewLeaf) as a to get video info from YouTube.
 
 Originally forked from [YTSponsorSkip](https://github.com/NDevTK/YTSponsorSkip), but very little code remains.
+The project also incorporates original code from SponsorBlock and DeArrow, both by Ajay Ramachandran and Michael R. H. Chang.
 
 Icons made by:
 * <a href="https://www.flaticon.com/authors/gregor-cresnar" title="Gregor Cresnar">Gregor Cresnar</a> from <a href="https://www.flaticon.com/" title="Flaticon">www.flaticon.com</a> and are licensed by <a href="https://creativecommons.org/licenses/by/3.0/" title="Creative Commons BY 3.0" target="_blank">CC 3.0 BY</a>

--- a/public/icons/pencil.svg
+++ b/public/icons/pencil.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"><path fill="#fff" d="M14.1 7.1l2.9 2.9L6.1 20.7l-3.6.7.7-3.6L14.1 7.1zm0-2.8L1.4 16.9 0 24l7.1-1.4L19.8 9.9l-5.7-5.7zm7.1 4.3L24 5.7 18.3 0l-2.8 2.8 5.7 5.7z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewBox="0 0 24 24" preserveAspectRatio="none"><path fill="#fff" d="M14.1 7.1l2.9 2.9L6.1 20.7l-3.6.7.7-3.6L14.1 7.1zm0-2.8L1.4 16.9 0 24l7.1-1.4L19.8 9.9l-5.7-5.7zm7.1 4.3L24 5.7 18.3 0l-2.8 2.8 5.7 5.7z"/></svg>


### PR DESCRIPTION
Added preserveAspectRatio="none" to public/icons/pencil.svg.

This change is an attempt to ensure the pencil icon stretches to completely fill the 256x256 pixel area designated in the README, even if it causes distortion of the original aspect ratio. This addresses your feedback that the icon was not fully covering the area.

- [x] I agree to license my contribution under GPL-3.0 and agree to allow distribution on app stores as outlined in [LICENSE-APPSTORE](https://github.com/erkinalp/EditTogether/blob/master/LICENSE-APPSTORE.txt)

To test this pull request, follow the [instructions in the wiki](https://github.com/erkinalp/EditTogether/wiki/Testing-a-Pull-Request).

***
