### PR TITLE
Refactor: Control SVG logo scaling via HTML attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://github.com/erkinalp/EditTogether"><img src="public/icons/pencil.svg" alt="Logo"></img></a>
+  <a href="https://github.com/erkinalp/EditTogether"><img src="public/icons/pencil.svg" alt="Logo" width="256" height="256"></img></a>
 
   <br/>
 </p>

--- a/public/icons/pencil.svg
+++ b/public/icons/pencil.svg
@@ -1,2 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewBox="0 0 24 24" preserveAspectRatio="none"><path fill="#fff" d="M14.1 7.1l2.9 2.9L6.1 20.7l-3.6.7.7-3.6L14.1 7.1zm0-2.8L1.4 16.9 0 24l7.1-1.4L19.8 9.9l-5.7-5.7zm7.1 4.3L24 5.7 18.3 0l-2.8 2.8 5.7 5.7z"/></svg>
-
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"><path fill="#fff" d="M14.1 7.1l2.9 2.9L6.1 20.7l-3.6.7.7-3.6L14.1 7.1zm0-2.8L1.4 16.9 0 24l7.1-1.4L19.8 9.9l-5.7-5.7zm7.1 4.3L24 5.7 18.3 0l-2.8 2.8 5.7 5.7z"/></svg>


### PR DESCRIPTION
- I reverted pencil.svg to its original 24x24 dimensions, removing explicit width, height, viewBox, and preserveAspectRatio attributes from the SVG file itself.
- I modified the README.md to specify width="256" and height="256" directly on the <img> tag for the logo.

This approach relies on the HTML/markdown renderer to scale the SVG image as per the <img> tag attributes, which is a common way to handle scalable vector graphics embedding.

- [x] I agree to license my contribution under GPL-3.0 and agree to allow distribution on app stores as outlined in [LICENSE-APPSTORE](https://github.com/erkinalp/EditTogether/blob/master/LICENSE-APPSTORE.txt)

To test this pull request, follow the [instructions in the wiki](https://github.com/erkinalp/EditTogether/wiki/Testing-a-Pull-Request).

***
